### PR TITLE
Fix `open` check to allow for ng-open.

### DIFF
--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -303,7 +303,7 @@ angular.module('ayAccordion', [])
       });
 
       $attrs.$observe('open', function(newval) {
-        if (newval != null) {
+        if (newval || newval === "") {
           if (!$element.hasClass('open')) {
             selfCtrl.open();
           }


### PR DESCRIPTION
`ng-open` sets this to false, so it's probably better to whitelist the `""` case.

/cc @isuda 
