### PR TITLE
Injector fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "repository": "AyogoHealth/ay-accordion",
   "main": "dist/index.js",
-  "jsnext:main": "dist/index.es6.js",
+  "module": "dist/index.es6.js",
   "typings": "dist/index.d.ts",
   "dependencies": {
     "@types/angular": "^1.5.17",
@@ -30,17 +30,7 @@
     "angular": "^1.4.0"
   },
   "devDependencies": {
-    "typescript": "^2.0.6"
-  },
-  "browserify": {
-    "transform": [
-      [
-        "browserify-ngannotate",
-        {
-          "sourcemap": true
-        }
-      ]
-    ]
+    "typescript": "^2.1.0"
   },
   "scripts": {
     "dist": "tsc -p . && cp src/index.ts dist/index.es6.js",

--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -38,9 +38,7 @@ angular.module('ayAccordion', [])
 .directive('ayAccordionRoot', function() {
   return {
     restrict: 'A',
-    controller: function($scope, $element, $attrs) {
-      "ngInject";
-
+    controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
       // Helper Methods //////////////////////////////////////////////////////
       var filter  = Array.prototype.filter;
       var forEach = Array.prototype.forEach;
@@ -214,7 +212,7 @@ angular.module('ayAccordion', [])
           });
         }
       };
-    }
+    }]
   };
 })
 
@@ -226,9 +224,7 @@ angular.module('ayAccordion', [])
     bindToController: {
       onToggle: '&'
     },
-    controller: function($scope, $element, $attrs) {
-      "ngInject";
-
+    controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
       var self = this;
 
       self.rootCtrl = null;
@@ -293,7 +289,7 @@ angular.module('ayAccordion', [])
 
         self.rootCtrl.run(self.fn, cb);
       };
-    },
+    }],
     link: function($scope, $element, $attrs, $ctrls) {
       var selfCtrl = $ctrls[0];
       var rootCtrl = $ctrls[1];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
         "experimentalDecorators": true,
         "noLib": false,
         "outDir": "dist",
-        "inlineSourceMap": true,
+        "sourceMap": true,
         "inlineSources": true,
         "stripInternal": true,
         "pretty": true


### PR DESCRIPTION
* Inline our injection annotations rather than relying on a plugin like ng-annotate
* Remove the unneeded browserify config from package.json (since annotations are inline now)
* Switch sourcemaps to be external files, so they aren't bloating dist files
* Change `jsmain:next` to the standard-ish `module` in package.json (for Rollup & Webpack2)