### PR TITLE
Hide children elements when closing via the open attribute

### DIFF
--- a/src/accordion.ts
+++ b/src/accordion.ts
@@ -260,6 +260,11 @@ angular.module('ayAccordion', [])
         $scope.$applyAsync();
         self['onToggle']({state: false});
 
+        Array.prototype.forEach.call($element.children(), function(el) {
+          if (!el.hasAttribute('ay-accordion-header') && !el.querySelector('[ay-accordion-header]')) {
+            el.setAttribute('hidden', '');
+          }
+        });
 
         if (self.rootCtrl.curPanel === self) {
           self.rootCtrl.curPanel = null;


### PR DESCRIPTION
Set the hidden attribute for all non-header attributes when closing via the `close()` function.