### PR TITLE
Hide existing children when accordion initializes

### DIFF
--- a/src/web-component/ay-accordion/index.ts
+++ b/src/web-component/ay-accordion/index.ts
@@ -93,6 +93,8 @@ export class AyAccordion extends HTMLElement {
     };
 
     this.addEventListener('toggle', handleToggle);
+
+    Array.prototype.forEach.call(this.children, (el) => this.childCallback(el));
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
Under normal DOM parsing, the ay-accordion gets initialized before its child elements and they correctly trigger the MutationObserver and get marked `hidden` as they initialize.

But there are cases (such as when appending a document fragment, or HTML string, or when combined with various frameworks) that the ay-accordion element initializes pre-populated with children and they do not trigger the MutationObserver and do not get marked as hidden.

I feel like we had code like this somewhere in a previous version (maybe before web-component-izing?)... or maybe I imagined fixing this the last time I ran into this problem...